### PR TITLE
Fields - composite set of fields/properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-`Skrz\Meta` requires PHP `>= 5.3.0` and Symfony `>= 2.7.0`.
+`Skrz\Meta` requires PHP `>= 5.4.0` and Symfony `>= 2.7.0`.
 
 ## Installation
 
@@ -166,6 +166,40 @@ var_export($someCategory->name === "Some category");
 // TRUE
 ```
 
+### Fields
+
+- Fields represent set of symbolic field paths.
+- They are composite (fields can have sub-fields).
+- Fields can be supplied as `$filter` parameters in `to*()` methods.
+
+```php
+use Skrz\API\Category;
+use Skrz\API\Meta\CategoryMeta;
+use Skrz\Meta\Fields\Fields;
+
+$parentCategory = new Category();
+$parentCategory->name = "The parent category";
+$parentCategory->slug = "parent-category";
+
+$childCategory = new Category();
+$childCategory->name = "The child category";
+$childCategory->slug = "child-category";
+$childCategory->parentCategory = $parentCategory;
+
+
+var_export(CategoryMeta::toArray($childCategory, null, Fields::fromString("name,parentCategory{name}")));
+// array(
+//     "name" => "The child category",
+//     "parentCategory" => array(
+//         "name" => "The parent category",
+//     ),
+// )
+```
+
+Fields are inspired by:
+
+- [Facebook Graph API's `?fields=...` query parameter](https://developers.facebook.com/docs/graph-api/using-graph-api#fields)
+- [Google Protocol Buffers' `FieldMask`](https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto) (and its [JSON serialization](https://developers.google.com/protocol-buffers/docs/proto3#json))
 
 ### Annotations
 

--- a/bin/generate-reflection.php
+++ b/bin/generate-reflection.php
@@ -185,6 +185,8 @@ foreach ($classes as $className => $discoveryClassName) {
 			$method->getName() !== "getStaticProperties" &&
 			$method->getName() !== "isCloneable" &&
 			$method->getName() !== "isVariadic" &&
+			$method->getName() !== "getType" && // TODO: PHP 7
+			$method->getName() !== "isAnonymous" && // TODO: PHP 7
 //			$method->getName() !== "getDefaultProperties" &&
 			(strncmp($method->getName(), "get", 3) === 0 || ($is = (strncmp($method->getName(), "is", 2) === 0))) &&
 			($method->getNumberOfParameters() === 0 || $method->getName() === "getProperties" || $method->getName() === "getMethods")

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     }
   ],
   "require": {
-    "php": ">=5.3",
+    "php": ">=5.4",
     "doctrine/annotations": "~1.2",
     "nette/php-generator": "~2.3",
-    "symfony/finder": "~2.7",
-    "symfony/console": "~2.7"
+    "symfony/finder": "~2.7|~3.0",
+    "symfony/console": "~2.7|~3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.6"

--- a/gen-src/Google/Protobuf/Compiler/CodeGeneratorResponse/Meta/FileMeta.php
+++ b/gen-src/Google/Protobuf/Compiler/CodeGeneratorResponse/Meta/FileMeta.php
@@ -250,7 +250,7 @@ class FileMeta extends File implements MetaInterface, ProtobufMetaInterface
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Compiler/Meta/CodeGeneratorRequestMeta.php
+++ b/gen-src/Google/Protobuf/Compiler/Meta/CodeGeneratorRequestMeta.php
@@ -260,7 +260,7 @@ class CodeGeneratorRequestMeta extends CodeGeneratorRequest implements MetaInter
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Compiler/Meta/CodeGeneratorResponseMeta.php
+++ b/gen-src/Google/Protobuf/Compiler/Meta/CodeGeneratorResponseMeta.php
@@ -233,7 +233,7 @@ class CodeGeneratorResponseMeta extends CodeGeneratorResponse implements MetaInt
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/DescriptorProto/Meta/ExtensionRangeMeta.php
+++ b/gen-src/Google/Protobuf/DescriptorProto/Meta/ExtensionRangeMeta.php
@@ -210,7 +210,7 @@ class ExtensionRangeMeta extends ExtensionRange implements MetaInterface, Protob
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/DescriptorProto/Meta/ReservedRangeMeta.php
+++ b/gen-src/Google/Protobuf/DescriptorProto/Meta/ReservedRangeMeta.php
@@ -210,7 +210,7 @@ class ReservedRangeMeta extends ReservedRange implements MetaInterface, Protobuf
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/DescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/DescriptorProtoMeta.php
@@ -438,7 +438,7 @@ class DescriptorProtoMeta extends DescriptorProto implements MetaInterface, Prot
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/EnumDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/EnumDescriptorProtoMeta.php
@@ -253,7 +253,7 @@ class EnumDescriptorProtoMeta extends EnumDescriptorProto implements MetaInterfa
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/EnumOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/EnumOptionsMeta.php
@@ -236,7 +236,7 @@ class EnumOptionsMeta extends EnumOptions implements MetaInterface, ProtobufMeta
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/EnumValueDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/EnumValueDescriptorProtoMeta.php
@@ -240,7 +240,7 @@ class EnumValueDescriptorProtoMeta extends EnumValueDescriptorProto implements M
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/EnumValueOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/EnumValueOptionsMeta.php
@@ -223,7 +223,7 @@ class EnumValueOptionsMeta extends EnumValueOptions implements MetaInterface, Pr
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/FieldDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/FieldDescriptorProtoMeta.php
@@ -367,7 +367,7 @@ class FieldDescriptorProtoMeta extends FieldDescriptorProto implements MetaInter
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/FieldOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/FieldOptionsMeta.php
@@ -288,7 +288,7 @@ class FieldOptionsMeta extends FieldOptions implements MetaInterface, ProtobufMe
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/FileDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/FileDescriptorProtoMeta.php
@@ -459,7 +459,7 @@ class FileDescriptorProtoMeta extends FileDescriptorProto implements MetaInterfa
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/FileDescriptorSetMeta.php
+++ b/gen-src/Google/Protobuf/Meta/FileDescriptorSetMeta.php
@@ -210,7 +210,7 @@ class FileDescriptorSetMeta extends FileDescriptorSet implements MetaInterface, 
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/FileOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/FileOptionsMeta.php
@@ -450,7 +450,7 @@ class FileOptionsMeta extends FileOptions implements MetaInterface, ProtobufMeta
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/MessageOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/MessageOptionsMeta.php
@@ -262,7 +262,7 @@ class MessageOptionsMeta extends MessageOptions implements MetaInterface, Protob
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/MethodDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/MethodDescriptorProtoMeta.php
@@ -297,7 +297,7 @@ class MethodDescriptorProtoMeta extends MethodDescriptorProto implements MetaInt
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/MethodOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/MethodOptionsMeta.php
@@ -223,7 +223,7 @@ class MethodOptionsMeta extends MethodOptions implements MetaInterface, Protobuf
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/OneofDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/OneofDescriptorProtoMeta.php
@@ -206,7 +206,7 @@ class OneofDescriptorProtoMeta extends OneofDescriptorProto implements MetaInter
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/ServiceDescriptorProtoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/ServiceDescriptorProtoMeta.php
@@ -253,7 +253,7 @@ class ServiceDescriptorProtoMeta extends ServiceDescriptorProto implements MetaI
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/ServiceOptionsMeta.php
+++ b/gen-src/Google/Protobuf/Meta/ServiceOptionsMeta.php
@@ -223,7 +223,7 @@ class ServiceOptionsMeta extends ServiceOptions implements MetaInterface, Protob
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/SourceCodeInfoMeta.php
+++ b/gen-src/Google/Protobuf/Meta/SourceCodeInfoMeta.php
@@ -211,7 +211,7 @@ class SourceCodeInfoMeta extends SourceCodeInfo implements MetaInterface, Protob
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/Meta/UninterpretedOptionMeta.php
+++ b/gen-src/Google/Protobuf/Meta/UninterpretedOptionMeta.php
@@ -323,7 +323,7 @@ class UninterpretedOptionMeta extends UninterpretedOption implements MetaInterfa
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/SourceCodeInfo/Meta/LocationMeta.php
+++ b/gen-src/Google/Protobuf/SourceCodeInfo/Meta/LocationMeta.php
@@ -311,7 +311,7 @@ class LocationMeta extends Location implements MetaInterface, ProtobufMetaInterf
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Google/Protobuf/UninterpretedOption/Meta/NamePartMeta.php
+++ b/gen-src/Google/Protobuf/UninterpretedOption/Meta/NamePartMeta.php
@@ -219,7 +219,7 @@ class NamePartMeta extends NamePart implements MetaInterface, ProtobufMetaInterf
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Skrz/Meta/Fixtures/Protobuf/ClassWithEmbeddedMessageProperty/Meta/EmbeddedMeta.php
+++ b/gen-src/Skrz/Meta/Fixtures/Protobuf/ClassWithEmbeddedMessageProperty/Meta/EmbeddedMeta.php
@@ -185,7 +185,7 @@ class EmbeddedMeta extends Embedded implements MetaInterface, PhpMetaInterface, 
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = NULL, array $filter = NULL)
+	public static function toArray($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -275,7 +275,7 @@ class EmbeddedMeta extends Embedded implements MetaInterface, PhpMetaInterface, 
 	 *
 	 * @return object
 	 */
-	public static function toObject($object, $group = NULL, array $filter = NULL)
+	public static function toObject($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -393,7 +393,7 @@ class EmbeddedMeta extends Embedded implements MetaInterface, PhpMetaInterface, 
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithEmbeddedMessagePropertyMeta.php
+++ b/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithEmbeddedMessagePropertyMeta.php
@@ -186,7 +186,7 @@ class ClassWithEmbeddedMessagePropertyMeta extends ClassWithEmbeddedMessagePrope
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = NULL, array $filter = NULL)
+	public static function toArray($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -276,7 +276,7 @@ class ClassWithEmbeddedMessagePropertyMeta extends ClassWithEmbeddedMessagePrope
 	 *
 	 * @return object
 	 */
-	public static function toObject($object, $group = NULL, array $filter = NULL)
+	public static function toObject($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -393,7 +393,7 @@ class ClassWithEmbeddedMessagePropertyMeta extends ClassWithEmbeddedMessagePrope
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithFixed64PropertyMeta.php
+++ b/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithFixed64PropertyMeta.php
@@ -185,7 +185,7 @@ class ClassWithFixed64PropertyMeta extends ClassWithFixed64Property implements M
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = NULL, array $filter = NULL)
+	public static function toArray($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -275,7 +275,7 @@ class ClassWithFixed64PropertyMeta extends ClassWithFixed64Property implements M
 	 *
 	 * @return object
 	 */
-	public static function toObject($object, $group = NULL, array $filter = NULL)
+	public static function toObject($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -391,7 +391,7 @@ class ClassWithFixed64PropertyMeta extends ClassWithFixed64Property implements M
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithNoPropertyMeta.php
+++ b/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithNoPropertyMeta.php
@@ -171,7 +171,7 @@ class ClassWithNoPropertyMeta extends ClassWithNoProperty implements MetaInterfa
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = NULL, array $filter = NULL)
+	public static function toArray($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -251,7 +251,7 @@ class ClassWithNoPropertyMeta extends ClassWithNoProperty implements MetaInterfa
 	 *
 	 * @return object
 	 */
-	public static function toObject($object, $group = NULL, array $filter = NULL)
+	public static function toObject($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -350,7 +350,7 @@ class ClassWithNoPropertyMeta extends ClassWithNoProperty implements MetaInterfa
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithStringPropertyMeta.php
+++ b/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithStringPropertyMeta.php
@@ -185,7 +185,7 @@ class ClassWithStringPropertyMeta extends ClassWithStringProperty implements Met
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = NULL, array $filter = NULL)
+	public static function toArray($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -275,7 +275,7 @@ class ClassWithStringPropertyMeta extends ClassWithStringProperty implements Met
 	 *
 	 * @return object
 	 */
-	public static function toObject($object, $group = NULL, array $filter = NULL)
+	public static function toObject($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -393,7 +393,7 @@ class ClassWithStringPropertyMeta extends ClassWithStringProperty implements Met
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithVarintPropertyMeta.php
+++ b/gen-src/Skrz/Meta/Fixtures/Protobuf/Meta/ClassWithVarintPropertyMeta.php
@@ -185,7 +185,7 @@ class ClassWithVarintPropertyMeta extends ClassWithVarintProperty implements Met
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = NULL, array $filter = NULL)
+	public static function toArray($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -275,7 +275,7 @@ class ClassWithVarintPropertyMeta extends ClassWithVarintProperty implements Met
 	 *
 	 * @return object
 	 */
-	public static function toObject($object, $group = NULL, array $filter = NULL)
+	public static function toObject($object, $group = NULL, $filter = NULL)
 	{
 		if ($object === null) {
 			return null;
@@ -384,7 +384,7 @@ class ClassWithVarintPropertyMeta extends ClassWithVarintProperty implements Met
 	 *
 	 * @return string
 	 */
-	public static function toProtobuf($object, array $filter = NULL)
+	public static function toProtobuf($object, $filter = NULL)
 	{
 		$output = '';
 

--- a/src/Skrz/Meta/Fields/Fields.php
+++ b/src/Skrz/Meta/Fields/Fields.php
@@ -1,0 +1,173 @@
+<?php
+namespace Skrz\Meta\Fields;
+
+/**
+ * Fields parser - {@see fromString} - and converter - {@see fromArray}.
+ *
+ * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ */
+class Fields
+{
+
+	/**
+	 * Create empty {@link FieldsBuilderInterface} instance.
+	 *
+	 * @return FieldsBuilderInterface
+	 */
+	public static function builder()
+	{
+		return ScalarFields::getInstance();
+	}
+
+	/**
+	 * Convert given array into fields.
+	 *
+	 * @param array $input
+	 * @return FieldsBuilderInterface
+	 */
+	public static function fromArray($input = [])
+	{
+		$fields = ScalarFields::getInstance();
+
+		foreach ($input as $k => $v) {
+			if (is_array($v)) {
+				$fields = $fields->appendFields($k, self::fromArray($v));
+			} elseif (!!$v) {
+				$fields = $fields->appendField($k);
+			}
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Parse string into fields.
+	 *
+	 * @param $input
+	 * @param int $start
+	 * @param null $end
+	 * @return FieldsBuilderInterface
+	 */
+	public static function fromString($input, $start = 0, $end = null)
+	{
+		return self::appendFromString(self::builder(), $input, $start, $end);
+	}
+
+	/**
+	 * Add fields from given string to existing field set.
+	 *
+	 * @param FieldsBuilderInterface $builder
+	 * @param string $input
+	 * @param int $start
+	 * @param int $end
+	 * @return FieldsBuilderInterface
+	 */
+	public static function appendFromString(FieldsBuilderInterface $builder, $input, $start = 0, $end = null)
+	{
+		if ($end === null) {
+			$end = strlen($input);
+		}
+
+		while ($start < $end) {
+			$start = self::ltrim($input, $start, $end);
+
+			if ($start >= $end) {
+				return $builder;
+			}
+
+			$p = self::pos($input, $start, $end, ".{,");
+
+			if ($p === $end) {
+				$p = self::rtrim($input, $start, $p);
+				$builder = $builder->appendField(substr($input, $start, $p - $start));
+
+				$start = $end;
+
+			} else {
+				$fieldName = substr($input, $start, self::rtrim($input, $start, $p) - $start);
+
+				switch ($input[$p]) {
+					case ".":
+						for ($q = self::pos($input, $p, $end, "{,"); $q < $end && $input[$q] === "{"; ++$q) {
+							$q = self::findBalancedRightBrace($input, $q, $end);
+						}
+						$builder = $builder->appendFields(
+							$fieldName,
+							self::appendFromString($builder->builder($fieldName), $input, $p + 1, $q)
+						);
+
+						$start = $q + 1;
+						break;
+
+					case "{":
+						$balancedRightBrace = self::findBalancedRightBrace($input, $p, $end);
+						if ($balancedRightBrace + 1 < $end && $input[$balancedRightBrace + 1] !== ",") {
+							throw new \InvalidArgumentException(
+								"Invalid fields string '{$input}' - expected ',' at position " . ($balancedRightBrace + 1) . "."
+							);
+						}
+						$builder = $builder->appendFields(
+							$fieldName,
+							self::appendFromString($builder->builder($fieldName), $input, $p + 1, $balancedRightBrace)
+						);
+						$start = $balancedRightBrace + 2;
+						break;
+
+					case ",":
+						$builder = $builder->appendField($fieldName);
+						$start = $p + 1;
+						break;
+
+					default:
+						throw new \LogicException("Unhandled char '{$input[$p]}'.");
+				}
+			}
+		}
+
+		return $builder;
+	}
+
+	private static function pos($input, $start, $end, $charsList)
+	{
+		while ($start < $end && strpos($charsList, $input[$start]) === false) {
+			++$start;
+		}
+		return $start;
+	}
+
+	private static function ltrim($input, $start, $end, $charsList = " \t\n\r\0\x0B")
+	{
+		while ($start < $end && strpos($charsList, $input[$start]) !== false) {
+			++$start;
+		}
+		return $start;
+	}
+
+	private static function rtrim($input, $start, $end, $charsList = " \t\n\r\0\x0B")
+	{
+		while ($end > $start && strpos($charsList, $input[$end - 1]) !== false) {
+			--$end;
+		}
+		return $end;
+	}
+
+	private static function findBalancedRightBrace($input, $start, $end)
+	{
+		if ($input[$start] !== "{") {
+			throw new \InvalidArgumentException("Invalid fields string '{$input}' - no left brace at position {$start}.");
+		}
+
+		for ($start = $start + 1, $n = 1; $start < $end; ++$start) {
+			if ($input[$start] === "{") {
+				++$n;
+			} else if ($input[$start] === "}") {
+				if (--$n < 1) {
+					return $start;
+				}
+			}
+		}
+
+		throw new \InvalidArgumentException("Invalid fields string '{$input}' - unbalanced braces at position {$start}.");
+	}
+
+}

--- a/src/Skrz/Meta/Fields/FieldsBuilderInterface.php
+++ b/src/Skrz/Meta/Fields/FieldsBuilderInterface.php
@@ -1,0 +1,36 @@
+<?php
+namespace Skrz\Meta\Fields;
+
+/**
+ * Builder allows to update fields in field set.
+ *
+ * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ */
+interface FieldsBuilderInterface extends FieldsInterface
+{
+
+	/**
+	 * Set field to be 'scalar' - ie. it is not composite, has no child fields.
+	 *
+	 * @param string $fieldName
+	 * @return FieldsBuilderInterface
+	 */
+	public function appendField($fieldName);
+
+	/**
+	 * Update field to given `$fields` instance.
+	 *
+	 * @param string $fieldName
+	 * @param FieldsBuilderInterface $fields
+	 * @return FieldsBuilderInterface
+	 */
+	public function appendFields($fieldName, FieldsBuilderInterface $fields);
+
+	/**
+	 * Return {@link FieldsInterface} from this builder - can optimize inner structure for further faster access.
+	 *
+	 * @return FieldsInterface
+	 */
+	public function build();
+
+}

--- a/src/Skrz/Meta/Fields/FieldsInterface.php
+++ b/src/Skrz/Meta/Fields/FieldsInterface.php
@@ -1,0 +1,44 @@
+<?php
+namespace Skrz\Meta\Fields;
+
+/**
+ * Fields represent composite set of fields/properties .
+ *
+ * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ */
+interface FieldsInterface extends \Countable, \Iterator, \ArrayAccess
+{
+
+	/**
+	 * Returns true if given field name is in set.
+	 *
+	 * @param string $fieldName
+	 * @return bool
+	 */
+	public function field($fieldName);
+
+	/**
+	 * Returns nested field set for given field name, if field name is not in set, it will return empty set.
+	 *
+	 * @param string $fieldName
+	 * @return FieldsInterface
+	 */
+	public function fields($fieldName);
+
+	/**
+	 * If parameter `$fieldName` is not null, it wil return {@link FieldsBuilderInterface} for given field name,
+	 * if the parameters is null, it returns {@link FieldsBuilderInterface} for whole set.
+	 *
+	 * @param string $fieldName
+	 * @return FieldsBuilderInterface
+	 */
+	public function builder($fieldName = null);
+
+	/**
+	 * Serialize this field set into string.
+	 *
+	 * @return string
+	 */
+	public function __toString();
+
+}

--- a/src/Skrz/Meta/Fields/MapFields.php
+++ b/src/Skrz/Meta/Fields/MapFields.php
@@ -1,0 +1,123 @@
+<?php
+namespace Skrz\Meta\Fields;
+
+/**
+ * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ */
+class MapFields implements FieldsBuilderInterface
+{
+
+	/** @var FieldsBuilderInterface[] */
+	private $map = [];
+
+	public function appendField($fieldName)
+	{
+		$this->map[$fieldName] = ScalarFields::getInstance();
+		return $this;
+	}
+
+	public function appendFields($fieldName, FieldsBuilderInterface $fields)
+	{
+		$this->map[$fieldName] = $fields;
+		return $this;
+	}
+
+	public function build()
+	{
+		return $this;
+	}
+
+	public function field($fieldName)
+	{
+		return isset($this->map[$fieldName]);
+	}
+
+	public function fields($fieldName)
+	{
+		if (isset($this->map[$fieldName])) {
+			return $this->map[$fieldName];
+		}
+
+		return ScalarFields::getInstance();
+	}
+
+	public function count()
+	{
+		return count($this->map);
+	}
+
+	public function builder($fieldName = null)
+	{
+		if ($fieldName === null) {
+			return $this;
+		} else if (isset($this->map[$fieldName])) {
+			return $this->map[$fieldName];
+		}
+
+		return ScalarFields::getInstance();
+	}
+
+	public function current()
+	{
+		return current($this->map);
+	}
+
+	public function next()
+	{
+		next($this->map);
+	}
+
+	public function key()
+	{
+		return key($this->map);
+	}
+
+	public function valid()
+	{
+		return !!$this->current();
+	}
+
+	public function rewind()
+	{
+		reset($this->map);
+	}
+
+	public function offsetExists($offset)
+	{
+		return $this->field($offset);
+	}
+
+	public function offsetGet($offset)
+	{
+		return $this->fields($offset);
+	}
+
+	public function offsetSet($offset, $value)
+	{
+		throw new \LogicException("Cannot set field '{$offset}'.");
+	}
+
+	public function offsetUnset($offset)
+	{
+		throw new \LogicException("Cannot unset field '{$offset}'.");
+	}
+
+	public function __toString()
+	{
+		$s = "";
+
+		foreach ($this->map as $k => $v) {
+			if (!empty($s)) {
+				$s .= ",";
+			}
+
+			$s .= $k;
+			if (count($v)) {
+				$s .= "{" . $v->__toString() . "}";
+			}
+		}
+
+		return $s;
+	}
+
+}

--- a/src/Skrz/Meta/Fields/ScalarFields.php
+++ b/src/Skrz/Meta/Fields/ScalarFields.php
@@ -1,0 +1,113 @@
+<?php
+namespace Skrz\Meta\Fields;
+
+/**
+ * @author Jakub Kulhan <jakub.kulhan@gmail.com>
+ */
+class ScalarFields implements FieldsBuilderInterface
+{
+
+	/**
+	 * @var ScalarFields
+	 */
+	private static $instance;
+
+	private function __construct()
+	{
+	}
+
+	public static function getInstance()
+	{
+		if (self::$instance === null) {
+			self::$instance = new ScalarFields();
+		}
+
+		return self::$instance;
+	}
+
+	public function appendField($fieldName)
+	{
+		$map = new MapFields();
+		return $map->appendFields($fieldName, $this);
+	}
+
+	public function appendFields($fieldName, FieldsBuilderInterface $fields)
+	{
+		$map = new MapFields();
+		return $map->appendFields($fieldName, $fields);
+	}
+
+	public function build()
+	{
+		return $this;
+	}
+
+	public function field($fieldName)
+	{
+		return false;
+	}
+
+	public function fields($fieldName)
+	{
+		return $this;
+	}
+
+	public function count()
+	{
+		return 0;
+	}
+
+	public function builder($fieldName = null)
+	{
+		return $this;
+	}
+
+	public function current()
+	{
+		return null;
+	}
+
+	public function next()
+	{
+	}
+
+	public function key()
+	{
+		return null;
+	}
+
+	public function valid()
+	{
+		return false;
+	}
+
+	public function rewind()
+	{
+	}
+
+	public function offsetExists($offset)
+	{
+		return $this->field($offset);
+	}
+
+	public function offsetGet($offset)
+	{
+		return $this->fields($offset);
+	}
+
+	public function offsetSet($offset, $value)
+	{
+		throw new \LogicException("Cannot set field '{$offset}'.");
+	}
+
+	public function offsetUnset($offset)
+	{
+		throw new \LogicException("Cannot unset field '{$offset}'.");
+	}
+
+	public function __toString()
+	{
+		return "";
+	}
+
+}

--- a/src/Skrz/Meta/JSON/JsonMetaInterface.php
+++ b/src/Skrz/Meta/JSON/JsonMetaInterface.php
@@ -1,10 +1,13 @@
 <?php
 namespace Skrz\Meta\JSON;
 
+use Skrz\Meta\Fields\FieldsInterface;
+use Skrz\Meta\MetaInterface;
+
 /**
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
  */
-interface JsonMetaInterface
+interface JsonMetaInterface extends MetaInterface
 {
 
 	/**
@@ -23,7 +26,7 @@ interface JsonMetaInterface
 	 *
 	 * @param object $object
 	 * @param string $group
-	 * @param array|int $filterOrOptions
+	 * @param array|FieldsInterface|int $filterOrOptions
 	 * @param int $options
 	 *
 	 * @return array
@@ -46,7 +49,7 @@ interface JsonMetaInterface
 	 *
 	 * @param object $object
 	 * @param string $group
-	 * @param array|int $filterOrOptions
+	 * @param array|FieldsInterface|int $filterOrOptions
 	 * @param int $options
 	 *
 	 * @return array

--- a/src/Skrz/Meta/PHP/PhpMetaInterface.php
+++ b/src/Skrz/Meta/PHP/PhpMetaInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace Skrz\Meta\PHP;
 
+use Skrz\Meta\Fields\FieldsInterface;
 use Skrz\Meta\MetaInterface;
 
 /**
@@ -25,11 +26,11 @@ interface PhpMetaInterface extends MetaInterface
 	 *
 	 * @param object $object
 	 * @param string $group
-	 * @param array $filter
+	 * @param array|FieldsInterface $filter
 	 *
 	 * @return array
 	 */
-	public static function toArray($object, $group = PhpArrayOffset::DEFAULT_GROUP, array $filter = null);
+	public static function toArray($object, $group = PhpArrayOffset::DEFAULT_GROUP, $filter = null);
 
 	/**
 	 * Creates object from any object with public properties (mostly \stdClass)
@@ -47,10 +48,10 @@ interface PhpMetaInterface extends MetaInterface
 	 *
 	 * @param object $object
 	 * @param string $group
-	 * @param array $filter
+	 * @param array|FieldsInterface $filter
 	 *
 	 * @return \stdClass
 	 */
-	public static function toObject($object, $group = PhpArrayOffset::DEFAULT_GROUP, array $filter = null);
+	public static function toObject($object, $group = PhpArrayOffset::DEFAULT_GROUP, $filter = null);
 
 }

--- a/src/Skrz/Meta/PHP/PhpModule.php
+++ b/src/Skrz/Meta/PHP/PhpModule.php
@@ -326,7 +326,7 @@ class PhpModule extends AbstractModule
 			$to->setStatic(true);
 			$to->addParameter("object");
 			$to->addParameter("group")->setOptional(true);
-			$to->addParameter("filter")->setTypeHint("array")->setOptional(true);
+			$to->addParameter("filter")->setOptional(true);
 
 			$to
 				->addDocument("Serializes \\{$type->getName()} to " . strtolower($what))

--- a/src/Skrz/Meta/Protobuf/ProtobufMetaInterface.php
+++ b/src/Skrz/Meta/Protobuf/ProtobufMetaInterface.php
@@ -1,10 +1,13 @@
 <?php
 namespace Skrz\Meta\Protobuf;
 
+use Skrz\Meta\Fields\FieldsInterface;
+use Skrz\Meta\MetaInterface;
+
 /**
  * @author Jakub Kulhan <jakub.kulhan@gmail.com>
  */
-interface ProtobufMetaInterface
+interface ProtobufMetaInterface extends MetaInterface
 {
 
 	/**
@@ -23,10 +26,10 @@ interface ProtobufMetaInterface
 	 * Serializes object state to Protocol Buffers message.
 	 *
 	 * @param object $object
-	 * @param array $filter
+	 * @param array|FieldsInterface $filter
 	 *
 	 * @return array
 	 */
-	public static function toProtobuf($object, array $filter = null);
+	public static function toProtobuf($object, $filter = null);
 
 }

--- a/src/Skrz/Meta/Protobuf/ProtobufModule.php
+++ b/src/Skrz/Meta/Protobuf/ProtobufModule.php
@@ -356,7 +356,7 @@ class ProtobufModule extends AbstractModule
 		$toProtobuf = $class->addMethod("toProtobuf");
 		$toProtobuf->setStatic(true);
 		$toProtobuf->addParameter("object");
-		$toProtobuf->addParameter("filter", null)->setTypeHint("array");
+		$toProtobuf->addParameter("filter", null);
 		$toProtobuf
 			->addDocument("Serialized \\{$type->getName()} to Protocol Buffers message.")
 			->addDocument("")

--- a/src/Skrz/Meta/XML/XmlMetaInterface.php
+++ b/src/Skrz/Meta/XML/XmlMetaInterface.php
@@ -1,7 +1,10 @@
 <?php
 namespace Skrz\Meta\XML;
 
-interface XmlMetaInterface
+use Skrz\Meta\Fields\FieldsInterface;
+use Skrz\Meta\MetaInterface;
+
+interface XmlMetaInterface extends MetaInterface
 {
 
 	/**
@@ -20,7 +23,7 @@ interface XmlMetaInterface
 	 *
 	 * @param object $object
 	 * @param string $group
-	 * @param array|\XMLWriter|\DOMDocument $filterOrXml
+	 * @param array|FieldsInterface|\XMLWriter|\DOMDocument $filterOrXml
 	 * @param \XMLWriter|\DOMDocument|\DOMElement $xml
 	 * @param \DOMElement $el
 	 *

--- a/test/Skrz/Meta/Fields/FieldsTest.php
+++ b/test/Skrz/Meta/Fields/FieldsTest.php
@@ -1,0 +1,230 @@
+<?php
+namespace Skrz\Meta\Fields;
+
+class FieldsTest extends \PHPUnit_Framework_TestCase
+{
+
+	public function testFromArrayNoArg()
+	{
+		$fields = Fields::fromArray();
+		$this->assertCount(0, $fields);
+	}
+
+	public function testFromArrayEmptyArray()
+	{
+		$fields = Fields::fromArray([
+
+		]);
+
+		$this->assertCount(0, $fields);
+	}
+
+	public function testFromArraySingleField()
+	{
+		$fields = Fields::fromArray(["foo" => true]);
+
+		$this->assertCount(1, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertFalse($fields->field("bar"));
+		$this->assertCount(0, $fields->fields("foo"));
+	}
+
+	public function testFromArrayMultipleFields()
+	{
+		$fields = Fields::fromArray(["foo" => true, "bar" => 1]);
+
+		$this->assertCount(2, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertTrue($fields->field("bar"));
+		$this->assertFalse($fields->field("baz"));
+		$this->assertCount(0, $fields->fields("foo"));
+		$this->assertCount(0, $fields->fields("bar"));
+	}
+
+	public function testFromArraySingleNestedField()
+	{
+		$fields = Fields::fromArray(["foo" => ["bar" => 1]]);
+
+		$this->assertCount(1, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertFalse($fields->field("bar"));
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar"));
+	}
+
+	public function testFromArrayMultipleNestedFields()
+	{
+		$fields = Fields::fromArray(["foo" => ["bar" => 1], "baz" => ["qux" => true]]);
+
+		$this->assertCount(2, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertFalse($fields->field("bar"));
+		$this->assertTrue($fields->field("baz"));
+		$this->assertFalse($fields->field("qux"));
+
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar"));
+
+		$this->assertCount(1, $fields->fields("baz"));
+		$this->assertTrue($fields->fields("baz")->field("qux"));
+		$this->assertCount(0, $fields->fields("baz")->fields("qux"));
+	}
+
+	public function testFromStringEmptyString()
+	{
+		$fields = Fields::fromString("");
+
+		$this->assertCount(0, $fields);
+		$this->assertFalse($fields->field("foo"));
+	}
+
+	public function testFromStringSingleField()
+	{
+		$fields = Fields::fromString("foo");
+
+		$this->assertCount(1, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(0, $fields->fields("foo"));
+		$this->assertFalse($fields->field("bar"));
+	}
+
+	public function testFromStringMultipleFields()
+	{
+		$fields = Fields::fromString("foo,bar");
+
+		$this->assertCount(2, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(0, $fields->fields("foo"));
+		$this->assertTrue($fields->field("bar"));
+		$this->assertCount(0, $fields->fields("bar"));
+		$this->assertFalse($fields->field("baz"));
+	}
+
+	public function testFromStringMultipleFieldsWhitespace()
+	{
+		$fields = Fields::fromString("  foo\t\t,  bar  \t");
+
+		$this->assertCount(2, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(0, $fields->fields("foo"));
+		$this->assertTrue($fields->field("bar"));
+		$this->assertCount(0, $fields->fields("bar"));
+		$this->assertFalse($fields->field("baz"));
+	}
+
+	public function testFromStringDotNestedSingleField()
+	{
+		$fields = Fields::fromString("foo.bar");
+
+		$this->assertCount(1, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar"));
+	}
+
+	public function testFromStringDotNestedMultipleFields()
+	{
+		$fields = Fields::fromString("foo.bar,baz.qux,baz.kwanza");
+
+		$this->assertCount(2, $fields);
+
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar"));
+
+		$this->assertTrue($fields->field("baz"));
+		$this->assertCount(2, $fields->fields("baz"));
+		$this->assertTrue($fields->fields("baz")->field("qux"));
+		$this->assertCount(0, $fields->fields("baz")->fields("qux"));
+		$this->assertTrue($fields->fields("baz")->field("kwanza"));
+		$this->assertCount(0, $fields->fields("baz")->fields("kwanza"));
+	}
+
+	public function testFromStringBraceNestedSingleField()
+	{
+		$fields = Fields::fromString("foo{bar}");
+
+		$this->assertCount(1, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar"));
+	}
+
+	public function testFromStringBraceNestedMultipleFields()
+	{
+		$fields = Fields::fromString("foo{bar},baz{qux,kwanza}");
+
+		$this->assertCount(2, $fields);
+
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar"));
+
+		$this->assertTrue($fields->field("baz"));
+		$this->assertCount(2, $fields->fields("baz"));
+		$this->assertTrue($fields->fields("baz")->field("qux"));
+		$this->assertCount(0, $fields->fields("baz")->fields("qux"));
+		$this->assertTrue($fields->fields("baz")->field("kwanza"));
+		$this->assertCount(0, $fields->fields("baz")->fields("kwanza"));
+	}
+
+	public function testFromStringBraceDeepNestedField()
+	{
+		$fields = Fields::fromString("foo{bar{baz{qux}}}");
+
+		$this->assertCount(1, $fields);
+		$this->assertTrue($fields->field("foo"));
+		$this->assertCount(1, $fields->fields("foo"));
+		$this->assertTrue($fields->fields("foo")->field("bar"));
+		$this->assertCount(1, $fields->fields("foo")->fields("bar"));
+		$this->assertTrue($fields->fields("foo")->fields("bar")->field("baz"));
+		$this->assertCount(1, $fields->fields("foo")->fields("bar")->fields("baz"));
+		$this->assertTrue($fields->fields("foo")->fields("bar")->fields("baz")->field("qux"));
+		$this->assertCount(0, $fields->fields("foo")->fields("bar")->fields("baz")->fields("qux"));
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testFromStringNoCommaAfterRightBrace()
+	{
+		Fields::fromString("foo{bar}baz");
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testFromStringUnbalancedBraces()
+	{
+		Fields::fromString("foo{bar");
+	}
+
+	/**
+	 * @dataProvider fieldsStrings
+	 */
+	public function testToString($input, $expected)
+	{
+		$this->assertEquals($expected, (string)Fields::fromString($input));
+	}
+
+	public function fieldsStrings()
+	{
+		return [
+			["", ""],
+			["foo,bar", "foo,bar"],
+			["  foo\t\t,  bar  \t", "foo,bar"],
+			["foo.bar", "foo{bar}"],
+			["foo.bar,baz.qux,baz.kwanza", "foo{bar},baz{qux,kwanza}"],
+			["foo{bar}", "foo{bar}"],
+			["foo{bar},baz{qux,kwanza}", "foo{bar},baz{qux,kwanza}"],
+			["foo{bar{baz{qux}}}", "foo{bar{baz{qux}}}"],
+		];
+	}
+
+}

--- a/test/Skrz/Meta/JsonModuleTest.php
+++ b/test/Skrz/Meta/JsonModuleTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Skrz\Meta;
 
+use Skrz\Meta\Fields\Fields;
 use Skrz\Meta\Fixtures\JSON\ClassWithArrayOfJsonRoot;
 use Skrz\Meta\Fixtures\JSON\ClassWithCustomNameProperty;
 use Skrz\Meta\Fixtures\JSON\ClassWithDiscriminatorValueA;
@@ -333,6 +334,108 @@ class JsonModuleTest extends \PHPUnit_Framework_TestCase
 					"a" => true,
 				],
 			])
+		);
+	}
+
+	public function testClassWithMorePropertiesFilteredFromArray()
+	{
+		$instance = new ClassWithMoreProperties();
+		$instance->a = "foo1";
+		$instance->b = "foo2";
+		$instance->c = "foo3";
+		$instance->d = "foo4";
+		$instance->e = "foo5";
+
+		$this->assertEquals(
+			'{"a":"foo1","b":"foo2","c":"foo3","d":"foo4","e":"foo5"}',
+			ClassWithMorePropertiesMeta::toJson($instance)
+		);
+
+		$this->assertEquals(
+			'{"a":"foo1"}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromArray([
+				"a" => true,
+			]))
+		);
+
+		$this->assertEquals(
+			'{"b":"foo2","c":"foo3","d":"foo4"}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromArray([
+				"b" => true,
+				"c" => true,
+				"d" => true,
+			]))
+		);
+
+		$instance2 = new ClassWithMoreProperties();
+		$instance2->a = "foo6";
+		$instance->f = $instance2;
+
+		$this->assertEquals(
+			'{"e":"foo5","f":{"a":"foo6","b":null}}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromArray([
+				"e" => true,
+				"f" => [
+					"a" => true,
+					"b" => true,
+				],
+			]))
+		);
+
+		$instance3 = new ClassWithMoreProperties();
+		$instance3->a = "foo7";
+		$instance->g = [$instance2, $instance3];
+
+		$this->assertEquals(
+			'{"g":[{"a":"foo6"},{"a":"foo7"}]}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromArray([
+				"g" => [
+					"a" => true,
+				],
+			]))
+		);
+	}
+
+	public function testClassWithMorePropertiesFilteredByFieldsFromString()
+	{
+		$instance = new ClassWithMoreProperties();
+		$instance->a = "foo1";
+		$instance->b = "foo2";
+		$instance->c = "foo3";
+		$instance->d = "foo4";
+		$instance->e = "foo5";
+
+		$this->assertEquals(
+			'{"a":"foo1","b":"foo2","c":"foo3","d":"foo4","e":"foo5"}',
+			ClassWithMorePropertiesMeta::toJson($instance)
+		);
+
+		$this->assertEquals(
+			'{"a":"foo1"}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromString("a"))
+		);
+
+		$this->assertEquals(
+			'{"b":"foo2","c":"foo3","d":"foo4"}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromString("b,c,d"))
+		);
+
+		$instance2 = new ClassWithMoreProperties();
+		$instance2->a = "foo6";
+		$instance->f = $instance2;
+
+		$this->assertEquals(
+			'{"e":"foo5","f":{"a":"foo6","b":null}}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromString("e,f{a,b}"))
+		);
+
+		$instance3 = new ClassWithMoreProperties();
+		$instance3->a = "foo7";
+		$instance->g = [$instance2, $instance3];
+
+		$this->assertEquals(
+			'{"g":[{"a":"foo6"},{"a":"foo7"}]}',
+			ClassWithMorePropertiesMeta::toJson($instance, null, Fields::fromString("g{a}"))
 		);
 	}
 

--- a/test/Skrz/Meta/PhpModuleTest.php
+++ b/test/Skrz/Meta/PhpModuleTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Skrz\Meta;
 
+use Skrz\Meta\Fields\Fields;
 use Skrz\Meta\Fixtures\PHP\ArrayCollection;
 use Skrz\Meta\Fixtures\PHP\ClassWithArrayProperty;
 use Skrz\Meta\Fixtures\PHP\ClassWithCustomOffsetProperty;
@@ -511,6 +512,166 @@ class PhpModuleTest extends \PHPUnit_Framework_TestCase
 					"a" => true,
 				],
 			])
+		);
+	}
+
+	public function testClassWithMorePropertiesFilteredByFieldsFromArray()
+	{
+		$instance = new ClassWithMoreProperties();
+		$instance->a = "foo1";
+		$instance->b = "foo2";
+		$instance->c = "foo3";
+		$instance->d = "foo4";
+		$instance->e = "foo5";
+
+		$this->assertEquals(
+			[
+				"a" => "foo1",
+				"b" => "foo2",
+				"c" => "foo3",
+				"d" => "foo4",
+				"e" => "foo5",
+				"f" => null,
+				"g" => [],
+			],
+			ClassWithMorePropertiesMeta::toArray($instance)
+		);
+
+		$this->assertEquals(
+			[
+				"a" => "foo1",
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromArray([
+				"a" => true,
+			]))
+		);
+
+		$this->assertEquals(
+			[
+				"b" => "foo2",
+				"c" => "foo3",
+				"d" => "foo4",
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromArray([
+				"b" => true,
+				"c" => true,
+				"d" => true,
+			]))
+		);
+
+		$instance2 = new ClassWithMoreProperties();
+		$instance2->a = "foo6";
+		$instance->f = $instance2;
+
+		$this->assertEquals(
+			[
+				"e" => "foo5",
+				"f" => [
+					"a" => "foo6",
+					"b" => null,
+				],
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromArray([
+				"e" => true,
+				"f" => [
+					"a" => true,
+					"b" => true,
+				],
+			]))
+		);
+
+		$instance3 = new ClassWithMoreProperties();
+		$instance3->a = "foo7";
+		$instance->g = [$instance2, $instance3];
+
+		$this->assertEquals(
+			[
+				"g" => [
+					[
+						"a" => "foo6",
+					],
+					[
+						"a" => "foo7",
+					]
+				],
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromArray([
+				"g" => [
+					"a" => true,
+				],
+			]))
+		);
+	}
+
+	public function testClassWithMorePropertiesFilteredByFieldsFromString()
+	{
+		$instance = new ClassWithMoreProperties();
+		$instance->a = "foo1";
+		$instance->b = "foo2";
+		$instance->c = "foo3";
+		$instance->d = "foo4";
+		$instance->e = "foo5";
+
+		$this->assertEquals(
+			[
+				"a" => "foo1",
+				"b" => "foo2",
+				"c" => "foo3",
+				"d" => "foo4",
+				"e" => "foo5",
+				"f" => null,
+				"g" => [],
+			],
+			ClassWithMorePropertiesMeta::toArray($instance)
+		);
+
+		$this->assertEquals(
+			[
+				"a" => "foo1",
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromString("a"))
+		);
+
+		$this->assertEquals(
+			[
+				"b" => "foo2",
+				"c" => "foo3",
+				"d" => "foo4",
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromString("b,c,d"))
+		);
+
+		$instance2 = new ClassWithMoreProperties();
+		$instance2->a = "foo6";
+		$instance->f = $instance2;
+
+		$this->assertEquals(
+			[
+				"e" => "foo5",
+				"f" => [
+					"a" => "foo6",
+					"b" => null,
+				],
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromString("e,f{a,b}"))
+		);
+
+		$instance3 = new ClassWithMoreProperties();
+		$instance3->a = "foo7";
+		$instance->g = [$instance2, $instance3];
+
+		$this->assertEquals(
+			[
+				"g" => [
+					[
+						"a" => "foo6",
+					],
+					[
+						"a" => "foo7",
+					]
+				],
+			],
+			ClassWithMorePropertiesMeta::toArray($instance, null, Fields::fromString("g{a}"))
 		);
 	}
 


### PR DESCRIPTION
Fields represent composite set symbolic paths to properties to be included in response, or to by updated by mutation operation.

Inspired by:
- Facebook Graph API's `?fields=...` parameter (which itself is a subset of [GraphQL](https://facebook.github.io/graphql/)) - see https://developers.facebook.com/docs/graph-api/using-graph-api#fields
- Google Protocol Buffers `FieldMask` - see https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto & https://developers.google.com/protocol-buffers/docs/proto3#json

`FieldsInterface` can be used in `*Meta`'s `to*()` methods as `$filter` parameter.

This changes introduces backward incompatibility in `PhpMetaInterface` and `ProtobufMetaInterface` => after the merge, new major version should be tagged.

Also this change updates Symfony composer dependency and removes PHP 5.3 compatibility.
